### PR TITLE
Server start/stop scripts have been renamed

### DIFF
--- a/content/docs/local_registry/_index.md
+++ b/content/docs/local_registry/_index.md
@@ -24,6 +24,6 @@ To initialise a local registry, run the following command from your terminal:
 
 This will install the registry and all the related files will be stored in `~/.fair`.
 
-To run the server, run the `~/.fair/registry/scripts/run_scrc_server` script, then navigate to http://localhost:8000 in your browser to check that the server is up and running. A token will be automatically generated in `~/.fair/registry/token`.
+To run the server, run the `~/.fair/registry/scripts/start_fair_registry` script, then navigate to http://localhost:8000 in your browser to check that the server is up and running. A token will be automatically generated in `~/.fair/registry/token`.
 
-To stop the server, run the `~/.fair/registry/scripts/stop_scrc_server` script.
+To stop the server, run the `~/.fair/registry/scripts/stop_fair_registry` script.


### PR DESCRIPTION
The original scripts for starting and stopping the local registry, i.e. `run_scrc_server` and `stop_scrc_server` have been renamed. This corrects the name of the scripts.

See https://github.com/FAIRDataPipeline/data-registry/issues/73