### PR TITLE
Move to www.fairdatapipeline.org

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,5 +20,5 @@ jobs:
       uses: benmatselby/hugo-deploy-gh-pages@master
       env:
         HUGO_EXTENDED: true
-        TARGET_REPO: FAIRDataPipeline/FAIRDataPipeline.github.io
+        TARGET_REPO: FAIRDataPipeline/www.fairdatapipeline.org
         TOKEN: ${{ secrets.FDP_HUGO }}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # FDP_hugo
 
-The [FAIR Data Pipeline website](https://fairdatapipeline.github.io) contains information related to datasets, the data pipeline, and various other technical documents associated with the SCRC project.
+The [FAIR Data Pipeline website](https://www.fairdatapipeline.org/) contains information related to datasets, the data pipeline, and various other technical documents associated with the SCRC project.
 
-* [ScottishCovidResponse/ScottishCovidResponse.github.io](https://github.com/FAIRDataPipeline/FAIRDataPipeline.github.io) contains website source files.
+* [FairDataPipeline/www.fairdatapipeline.org](https://github.com/FAIRDataPipeline/www.fairdatapipeline.org) contains website source files.
 
-* [ScottishCovidResponse/hugo_source_files](https://github.com/FAIRDataPipeline/FDP_hugo) contains Hugo source files 
-  * When pushes are made to this repository, a GitHub actions workflow automatically deploys source files to ScottishCovidResponse/ScottishCovidResponse.github.io
+* [FAIRDataPipeline/FDP_hugo](https://github.com/FAIRDataPipeline/FDP_hugo) contains Hugo source files 
+  * When pushes are made to this repository, a GitHub actions workflow automatically deploys source files to FAIRDataPipeline/www.fairdatapipeline.org
 
 * [ScottishCovidResponse/hugo-book](https://github.com/ScottishCovidResponse/hugo-book) contains Hugo theme files
   * This theme is based on the Hugo [Book](https://github.com/alex-shpak/hugo-book) theme, with the search bar from the Jekyll [Just the Docs](https://github.com/pmarsceill/just-the-docs) theme, and some extra tweaks

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 # hugo server --minify --themesDir ... --baseURL=http://0.0.0.0:1313/theme/hugo-book/
 
-baseURL = 'https://FAIRDataPipeline.github.io/'
+baseURL = 'https://www.fairdatapipeline.org/'
 title = 'FAIRDataPipeline'
 theme = 'hugo-book'
 enableEmoji = true

--- a/content/docs/API/R/_index.md
+++ b/content/docs/API/R/_index.md
@@ -13,4 +13,4 @@ install.packages("devtools")
 devtools::install_github("FAIRDataPipeline/rDataPipeline")
 ```
 
-To view the package documentation, go [here](https://FAIRDataPipeline.github.io/rDataPipeline/index.html).
+To view the package documentation, go [here](https://www.fairdatapipeline.org/rDataPipeline/index.html).

--- a/content/docs/API/julia/_index.md
+++ b/content/docs/API/julia/_index.md
@@ -29,5 +29,5 @@ See the [package documentation][docs] for instructions and examples.
 
 See the package's [code repo][repo].
 
-[docs]: https://FAIRDataPipeline.github.io/DataPipeline.jl/stable/
+[docs]: https://www.fairdatapipeline.org/DataPipeline.jl/stable/
 [repo]: https://github.com/FAIRDataPipeline/DataPipeline.jl


### PR DESCRIPTION
Update links to www.fairdatapipeline.org and change repo for static pages to same